### PR TITLE
Include basic Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:alpine
+
+# Set the Current Working Directory inside the container
+RUN mkdir -p /api
+WORKDIR /api
+
+# Copy everything from the current directory to the PWD (Present Working Directory) inside the container
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+
+# TODO Build multi-stage Dockerfile
+# 1. build/compile stage
+# 2. run stage
+# RUN go build -o ./app ./main.go
+
+# # Install the package
+# RUN go install -v ./...
+
+# This container exposes port 8080 to the outside world
+EXPOSE 8080
+
+# Run the executable
+ENTRYPOINT ["go", "run", "."]

--- a/main.go
+++ b/main.go
@@ -97,5 +97,5 @@ func main() {
 	router := gin.Default()
 	router.GET("/logs", getLogs)
 
-	router.Run("localhost:8080")
+	router.Run(":8080")
 }


### PR DESCRIPTION
                    ##        .            
              ## ## ##       ==            
           ## ## ## ##      ===            
       /""""""""""""""""\___/ ===        
       \______ o          __/            
         \    \        __/             
          \____\______/                
 

Added Basic Dockerfile.

1. At this stage we can probably dry run it on Monday
2. Would like to improve Dockerfile. Currently it does not compile the code, so I would like to create a multi stage Docker file with build and run stages
3. `docker build -t rlf .` To buld the image 
4. `docker run -p 8080:8080 rlf` To run the container
5. SPEND OVER 3 HOURS debugging the Docker container. Wanna know why it was not working? Check the **main.go** changes

![image](https://user-images.githubusercontent.com/10868221/137582640-da25866f-348a-44d2-a33d-a29b6541f115.png)
 